### PR TITLE
Lzpf compression Take 2

### DIFF
--- a/zefie_wtvp_minisrv/WTVLzpf.js
+++ b/zefie_wtvp_minisrv/WTVLzpf.js
@@ -1,5 +1,3 @@
-var EventEmitter = require('events').EventEmitter;
-
 /**
 * Pure-JS implementation of WebTV's LZPF compression
 *

--- a/zefie_wtvp_minisrv/WTVLzpf.js
+++ b/zefie_wtvp_minisrv/WTVLzpf.js
@@ -413,8 +413,8 @@ class WTVLzpf {
      * @returns {Buffer} Lzpf compression data
      */
     Finish() {
-        var code_length = -1
-        var code = -1
+        var code_length = -1;
+        var code = -1;
 
         if (this.type_index == 2) {
             this.EncodeLiteral(0x10, 0x00990000);

--- a/zefie_wtvp_minisrv/app.js
+++ b/zefie_wtvp_minisrv/app.js
@@ -589,6 +589,16 @@ async function sendToClient(socket, headers_obj, data) {
         delete headers_obj["Content-type"];
     }
 
+    // encrypt if needed
+    if (socket_sessions[socket.id].secure == true) {
+        headers_obj["wtv-encrypted"] = 'true';
+        headers_obj = moveObjectElement('wtv-encrypted', 'Connection', headers_obj);
+        if (clen > 0 && socket_sessions[socket.id].wtvsec) {
+            if (!zquiet) console.log(" * Encrypting response to client ...")
+            var enc_data = socket_sessions[socket.id].wtvsec.Encrypt(1, data);
+            data = enc_data;
+        }
+    }
 
     // if box can do compression, see if its worth enabling
     if (ssid_sessions[socket.ssid].capabilities) {
@@ -607,17 +617,6 @@ async function sendToClient(socket, headers_obj, data) {
         data = wtvcomp.Compress(data);
 
         wtvcomp = null; // Makes the garbage gods happy so it cleans up our mess
-    }
-
-    // encrypt if needed
-    if (socket_sessions[socket.id].secure == true) {
-        headers_obj["wtv-encrypted"] = 'true';
-        headers_obj = moveObjectElement('wtv-encrypted', 'Connection', headers_obj);
-        if (clen > 0 && socket_sessions[socket.id].wtvsec) {
-            if (!zquiet) console.log(" * Encrypting response to client ...")
-            var enc_data = socket_sessions[socket.id].wtvsec.Encrypt(1, data);
-            data = enc_data;
-        }
     }
 
     // calculate content length

--- a/zefie_wtvp_minisrv/app.js
+++ b/zefie_wtvp_minisrv/app.js
@@ -708,8 +708,6 @@ function shouldWeCompress(content_type) {
     if (typeof (content_type) != 'undefined') {
         if ((content_type.match(/^text\//) && content_type != "text/tellyscript") ||
             content_type.match(/^application\/(x-?)javascript$/) ||
-            content_type.match(/^audio\/(x-)?midi/) ||
-            content_type.match(/^audio\/(x-)?wav/) ||
             content_type == "application/json") {
             return true;
         }

--- a/zefie_wtvp_minisrv/app.js
+++ b/zefie_wtvp_minisrv/app.js
@@ -707,6 +707,8 @@ function shouldWeCompress(content_type) {
     if (typeof (content_type) != 'undefined') {
         if ((content_type.match(/^text\//) && content_type != "text/tellyscript") ||
             content_type.match(/^application\/(x-?)javascript$/) ||
+            content_type.match(/^audio\/(x-)?midi/) ||
+            content_type.match(/^audio\/(x-)?wav/) ||
             content_type == "application/json") {
             return true;
         }


### PR DESCRIPTION
I think I got the Lzpf replicated as it was last designed.  It seems the corruption for MIDI files etc... is baked into Lzpf.  I can "fix" it by compressing after RC4 but we loose compressibility since encryption is random by nature.  It seems this is the "fix" the service actually used.  I'm just disabling Lzpf in those cases for now (until I see more I can do)

There's a flaw with the algorithm where it corrupts on some data and I think that's why they only used Lzpf in very few cases where there was text data.  Technically it can be fixed by creating a version of Lzpf that's different than what was on the service but I'm leaving it as-is for now.